### PR TITLE
Autoincrementing Versioning System Working

### DIFF
--- a/Northwind-Basic/src/com_pekinsoft_northwind_basic/classes/com/pekinsoft/northwind/basic/Application.java
+++ b/Northwind-Basic/src/com_pekinsoft_northwind_basic/classes/com/pekinsoft/northwind/basic/Application.java
@@ -52,7 +52,7 @@ import java.util.Properties;
 public class Application {
     //<editor-fold defaultstate="collapsed" desc="Public Static Constants">
     public static final Logger log;
-    public static final boolean DEBUGGING = true;
+    public static final boolean DEBUGGING;
     
     public static final int MAJOR;
     public static final int MINOR;
@@ -141,14 +141,14 @@ public class Application {
             companyDir.mkdirs();
             // Folder structure created \\
         }
-//        DEBUGGING = Boolean.parseBoolean(props.getProperty("debugging", "false"));
+        DEBUGGING = Boolean.parseBoolean(props.getProperty("debugging", "false"));
         long bui = Long.valueOf(props.getProperty("app.build", "0"));
         int rev = Integer.valueOf(props.getProperty("app.revision", "0"));
         int min = Integer.valueOf(props.getProperty("app.minor", "1"));
         int maj = Integer.valueOf(props.getProperty("app.major", "0"));
         
         log.debug("Calculating the version of the application.");
-        if ( Boolean.getBoolean(props.getProperty("debugging")) ) {
+        if ( DEBUGGING == true ) { //Boolean.getBoolean(props.getProperty("debugging")) ) {
 //            if ( bui == 0 ) {
 //                bui = 1583;
 //            } else {


### PR DESCRIPTION
I figured out what was wrong with the autoincrementing of the Build number. Though I don't exactly know why, the following code did *not* work:

```java
    if ( Boolean.getBoolean(props.getProperty("debugging")) ) {
		// Code to execute during debugging here...
	}
```

However, when I changed it to the following, the build number started incrementing as expected:

```java
	DEBUGGING = Boolean.parseBoolean(props.getProperty("debugging", "false"));

    if ( DEBUGGING == true ) {
		// Code to execute during debugging here...
	}
```

Now, as long as we are running the application from NetBeans in development/debugging mode, we will have an incrementing Build number. Once the build reaches 9999, the next time we debug it will change to zero (0) and the Revision will increment by one (1).

I am going to close Issue #4 with this commit.